### PR TITLE
feat: ios 14.2 애니메이션 미적용 버그 테스트

### DIFF
--- a/toast_popup/index.html
+++ b/toast_popup/index.html
@@ -75,7 +75,7 @@
 
         .toast_layer2::before {
             flex: 1 0 100%;
-            transition: flex 0.5s ease-in-out;
+            transition: all 0.5s ease-in-out;
             content: '';
         }
 

--- a/toast_popup/index.html
+++ b/toast_popup/index.html
@@ -75,7 +75,7 @@
 
         .toast_layer2::before {
             flex: 1 0 100%;
-            transition: flex-basis 0.5s ease-in-out;
+            transition: flex 0.5s ease-in-out;
             content: '';
         }
 


### PR DESCRIPTION
`transition-property`의 **flex-basis** 값을 **all** 로 변경하면 애니메이션이 올바르게 적용됨

참고: https://developer.apple.com/forums/thread/131664